### PR TITLE
Support an http timeout in github update checker

### DIFF
--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
@@ -102,7 +103,7 @@ func (c OCIUpdateChecker) DownloadVersion(version string, requireChecksumMatch b
 }
 
 // GetLatestVersion will return the latest version information from the oci repository
-func (c OCIUpdateChecker) GetLatestVersion() (*updatechecker.VersionInfo, error) {
+func (c OCIUpdateChecker) GetLatestVersion(timeout time.Duration) (*updatechecker.VersionInfo, error) {
 	repo, err := remote.NewRepository(c.artifact)
 	if err != nil {
 		return nil, err

--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -23,7 +23,7 @@ type UpdateInfo struct {
 }
 
 type UpdateChecker interface {
-	GetLatestVersion() (*VersionInfo, error)
+	GetLatestVersion(timeout time.Duration) (*VersionInfo, error)
 	DownloadVersion(version string, requireChecksumMatch bool) (string, error)
 }
 

--- a/updateinfo.go
+++ b/updateinfo.go
@@ -11,7 +11,7 @@ import (
 func (s SDK) GetUpdateInfo() (*updatechecker.UpdateInfo, error) {
 	checkedAt := time.Now()
 
-	latestVersion, err := s.updateChecker.GetLatestVersion()
+	latestVersion, err := s.updateChecker.GetLatestVersion(s.httpTimeout)
 	if err != nil {
 		return nil, errors.Wrap(err, "get latest version")
 	}

--- a/usrbin.go
+++ b/usrbin.go
@@ -1,6 +1,8 @@
 package usrbin
 
 import (
+	"time"
+
 	"github.com/usrbinapp/usrbin-go/pkg/github"
 	"github.com/usrbinapp/usrbin-go/pkg/homebrew"
 	"github.com/usrbinapp/usrbin-go/pkg/oci"
@@ -46,10 +48,21 @@ func UsingHomebrewFormula(formula string) Option {
 	}
 }
 
+// UsingHttpTimeout will set the timeout for all http requests
+// made by this sdk
+func UsingHttpTimeout(d time.Duration) Option {
+	return func(sdk *SDK) error {
+		sdk.httpTimeout = d
+		return nil
+	}
+}
+
 func New(version string, opts ...Option) (*SDK, error) {
 	sdk := SDK{
 		version: version,
 	}
+
+	sdk.httpTimeout = 10 * time.Second
 
 	if err := sdk.parseOptions(opts); err != nil {
 		return nil, err

--- a/usrbinsdk.go
+++ b/usrbinsdk.go
@@ -1,6 +1,8 @@
 package usrbin
 
 import (
+	"time"
+
 	"github.com/usrbinapp/usrbin-go/pkg/pkgmgr"
 	"github.com/usrbinapp/usrbin-go/pkg/updatechecker"
 )
@@ -13,5 +15,6 @@ type SDK struct {
 	version                 string
 	updateChecker           updatechecker.UpdateChecker
 	externalPackageManagers []pkgmgr.ExternalPackageManager
+	httpTimeout             time.Duration
 	logger                  Logger
 }


### PR DESCRIPTION
This creates a new option WithHttpTimeout that's respected in the github update checker.